### PR TITLE
Update relationships.md

### DIFF
--- a/docs/learn/concepts/relationships.md
+++ b/docs/learn/concepts/relationships.md
@@ -47,21 +47,9 @@ Get parent for entity
 world:parent(bob)
 ```
 ```typescript [typescript]
-world.parent(bob, pair(Eats, jecs.Wildcard)
+world.parent(bob)
 ```
 :::
-
-Find first target of a relationship for entity
-
-:::code-group
-```luau [luau]
-world:target(bob, Eats)
-```
-```typescript [typescript]
-world.target(bob, Eats)
-```
-:::
-
 
 Find first target of a relationship for entity
 


### PR DESCRIPTION
## Removed duplicate description for 'find first target of a relationship' and fixed the incorrect typescript (I hope) example of getting the parent of an entity.